### PR TITLE
Fixing Run-time NullreferenceException

### DIFF
--- a/src/DbExtensions/PocoMapper.cs
+++ b/src/DbExtensions/PocoMapper.cs
@@ -370,7 +370,8 @@ namespace DbExtensions {
       }
 
       void SetProperty(ref object instance, object value) {
-         this.Setter.Invoke(instance, new object[1] { value });
+          if (value == null) return;
+          Setter.Invoke(instance, new object[1] { Convert.ChangeType(value, this.UnderlyingType, System.Globalization.CultureInfo.InvariantCulture) });
       }
 
       public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) {


### PR DESCRIPTION
First of all thank you for DbExtensions for the time you spend to write the library it save me a lot of time and i am so happy using DbExtensions i love it more than Dapper and it's very easy to use and implement and the library fit my projects perfectly.

my suggestion here :
This will fix NullreferenceException at Run-time if the value instance not created. Also will make sure to convert the value before invoke to the property. Due argumentexception at Run-time i faced during using DbExtensions

system.argumentexception: object of type 'system.int32' cannot be converted to type 'system.string'.